### PR TITLE
Fix language persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,7 +72,7 @@ export default function App() {
   const [order, setOrder] = useState([]);
   const [form, setForm] = useState({ age: "", gender: "", education: "" });
   const [submitted, setSubmitted] = useState(false);
-  const [lang, setLang] = useState("nl");
+  const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'nl');
   const [formErrors, setFormErrors] = useState({});
 
   // Update localStorage when language changes


### PR DESCRIPTION
## Summary
- persist chosen language across page reloads

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843475110288324b143cf9dd1f61b25