### PR TITLE
Fix JSX formatting in CaptchaVerification

### DIFF
--- a/src/components/CaptchaVerification.jsx
+++ b/src/components/CaptchaVerification.jsx
@@ -22,7 +22,8 @@ const CaptchaVerification = ({ onVerify }) => {
 
   return (
     <div className="flex flex-col items-center justify-center p-4">
-      <h2 className="text-xl mb-4">{window.location.hostname.includes('nl') ? 'Verifieer dat je een mens bent' : 'Please verify that you\'re human'}</h2>      <ReCAPTCHA
+      <h2 className="text-xl mb-4">{window.location.hostname.includes('nl') ? 'Verifieer dat je een mens bent' : 'Please verify that you\'re human'}</h2>
+      <ReCAPTCHA
         sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
         onChange={handleCaptchaVerify}
       />


### PR DESCRIPTION
## Summary
- add newline after closing `h2` tag for cleaner JSX formatting

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68434ab611e48324aa41be0866cd6918