### PR TITLE
Fix drag reorder index

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,7 +132,8 @@ export default function App() {
     const nu = order.indexOf(over.id);
     const newOrder = [...order];
     newOrder.splice(old, 1);
-    newOrder.splice(nu, 0, active.id);
+    const newIndex = old < nu ? nu - 1 : nu;
+    newOrder.splice(newIndex, 0, active.id);
     setOrder(newOrder);
   }
   function next() {


### PR DESCRIPTION
## Summary
- adjust `handleDragEnd` logic so that re-insertion index accounts for removed item
- run `npm install` and `npm run build`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68434aa87a2c8324b79f39d9f8a41d1c