### PR TITLE
Add next question image prefetch

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -108,6 +108,15 @@ export default function App() {
     if (typeof step === "number") {
       const qid = QUESTIONS[step].id;
       setOrder(answers[qid] ?? QUESTIONS[step].options);
+
+      // Prefetch images for the next question
+      if (step + 1 < QUESTIONS.length) {
+        const nextQ = QUESTIONS[step + 1];
+        nextQ.options.forEach(file => {
+          const img = new Image();
+          img.src = `mascots/${nextQ.id}/${file}`;
+        });
+      }
     }
   }, [step]);
 


### PR DESCRIPTION
## Summary
- prefetch images for the next question so they load faster

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434e87c628832485e859a3f2cf8271