### PR TITLE
Fix fallback image path

### DIFF
--- a/src/__tests__/sortableMascot.test.jsx
+++ b/src/__tests__/sortableMascot.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import SortableMascot from '../components/SortableMascot'
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: null,
+    isDragging: false
+  })
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: { toString: () => '' }
+  }
+}))
+
+let container
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  container.remove()
+  container = null
+})
+
+describe('SortableMascot', () => {
+  it('uses fallback image when asset fails to load', () => {
+    act(() => {
+      createRoot(container).render(
+        <SortableMascot id="friend_type-man.png" src="invalid.png" rank={1} />
+      )
+    })
+
+    const img = container.querySelector('img')
+    expect(img.getAttribute('src')).toBe('invalid.png')
+
+    act(() => {
+      img.dispatchEvent(new Event('error'))
+    })
+
+    expect(img.getAttribute('src')).toBe('mascots/missing.png')
+  })
+})

--- a/src/components/SortableMascot.jsx
+++ b/src/components/SortableMascot.jsx
@@ -63,7 +63,7 @@ export default function SortableMascot ({ id, src, rank }) {
       '
       >
         <img
-          src={fallback ? 'mascots/missing.jpg' : src}
+          src={fallback ? 'mascots/missing.png' : src}
           alt={label}
           className='h-full w-full object-contain'
           onError={() => setFallback(true)}


### PR DESCRIPTION
## Summary
- use `mascots/missing.png` when mascot images fail to load
- add unit test for `SortableMascot` fallback behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684740cb55488324be903bcc9e8e613d