### PR TITLE
Display disabled flag status

### DIFF
--- a/src/components/EnvironmentCheck.jsx
+++ b/src/components/EnvironmentCheck.jsx
@@ -14,32 +14,58 @@ const EnvironmentCheck = () => {
     }
   })
 
-  if (missingVars.length === 0) {
+  const disableSubmissionCheck = import.meta.env.VITE_DISABLE_SUBMISSION_CHECK === 'true'
+  const disableCaptcha = import.meta.env.VITE_DISABLE_CAPTCHA === 'true'
+
+  if (missingVars.length === 0 && !disableSubmissionCheck && !disableCaptcha) {
     return null
   }
 
   return (
-    <div className='bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4' role='alert'>
-      <strong className='font-bold'>⚠️ Waarschuwing / Warning: </strong>
-      <span className='block sm:inline'>
-        {window.location.hostname.includes('nl')
-          ? (
-            <>
-              De volgende omgevingsvariabelen ontbreken. De enquête zal niet werken zonder deze:
-              <ul className='list-disc list-inside mt-2'>
-                {missingVars.map(name => <li key={name}>{name}</li>)}
-              </ul>
-            </>
-            )
-          : (
-            <>
-              The following environment variables are missing. The survey will not work without them:
-              <ul className='list-disc list-inside mt-2'>
-                {missingVars.map(name => <li key={name}>{name}</li>)}
-              </ul>
-            </>
+    <div className='space-y-2 mb-4'>
+      {missingVars.length > 0 && (
+        <div className='bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative' role='alert'>
+          <strong className='font-bold'>⚠️ Waarschuwing / Warning: </strong>
+          <span className='block sm:inline'>
+            {window.location.hostname.includes('nl') ? (
+              <>
+                De volgende omgevingsvariabelen ontbreken. De enquête zal niet werken zonder deze:
+                <ul className='list-disc list-inside mt-2'>
+                  {missingVars.map(name => <li key={name}>{name}</li>)}
+                </ul>
+              </>
+            ) : (
+              <>
+                The following environment variables are missing. The survey will not work without them:
+                <ul className='list-disc list-inside mt-2'>
+                  {missingVars.map(name => <li key={name}>{name}</li>)}
+                </ul>
+              </>
             )}
-      </span>
+          </span>
+        </div>
+      )}
+
+      {(disableSubmissionCheck || disableCaptcha) && (
+        <div className='bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded relative' role='alert'>
+          <strong className='font-bold'>ℹ️ {window.location.hostname.includes('nl') ? 'Informatie' : 'Info'}: </strong>
+          <span className='block sm:inline'>
+            {disableSubmissionCheck && (
+              <>{window.location.hostname.includes('nl') ? 'Inzendingcontrole uitgeschakeld' : 'Submission check disabled'}{disableCaptcha ? '; ' : ''}</>
+            )}
+            {disableCaptcha && (
+              <>{window.location.hostname.includes('nl') ? 'CAPTCHA uitgeschakeld' : 'CAPTCHA disabled'}</>
+            )}
+          </span>
+        </div>
+      )}
+
+      <div className='bg-gray-100 border border-gray-400 text-gray-700 px-4 py-3 rounded relative' role='alert'>
+        <span className='block sm:inline text-sm'>
+          VITE_DISABLE_SUBMISSION_CHECK: {String(import.meta.env.VITE_DISABLE_SUBMISSION_CHECK)}<br />
+          VITE_DISABLE_CAPTCHA: {String(import.meta.env.VITE_DISABLE_CAPTCHA)}
+        </span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show values for `VITE_DISABLE_SUBMISSION_CHECK` and `VITE_DISABLE_CAPTCHA`
- add an info banner when submission checks or CAPTCHA are disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684740c69830832486650daf7162bae2