### PR TITLE
Add localized CAPTCHA prompt

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -267,7 +267,7 @@ export default function App () {
         </div>
         <div className='text-center'>
           <h1 className='text-3xl font-bold'>{t.title}</h1>
-          <CaptchaVerification onVerify={setIsVerified} />
+          <CaptchaVerification onVerify={setIsVerified} t={t} />
         </div>
         <div className='flex justify-center mt-8'>
           <img

--- a/src/components/CaptchaVerification.jsx
+++ b/src/components/CaptchaVerification.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import ReCAPTCHA from 'react-google-recaptcha'
 
-const CaptchaVerification = ({ onVerify }) => {
+const CaptchaVerification = ({ onVerify, t }) => {
   useEffect(() => {
     // If CAPTCHA is disabled, automatically verify
     if (import.meta.env.VITE_DISABLE_CAPTCHA === 'true') {
@@ -22,7 +22,7 @@ const CaptchaVerification = ({ onVerify }) => {
 
   return (
     <div className='flex flex-col items-center justify-center p-4'>
-      <h2 className='text-xl mb-4'>{window.location.hostname.includes('nl') ? 'Verifieer dat je een mens bent' : 'Please verify that you\'re human'}</h2>
+      <h2 className='text-xl mb-4'>{t.captchaPrompt}</h2>
       <ReCAPTCHA
         sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
         onChange={handleCaptchaVerify}

--- a/src/data/translations.js
+++ b/src/data/translations.js
@@ -3,6 +3,7 @@ export const translations = {
     title: 'Mascotte‑Survey',
     welcome:
       '👋 Welkom en bedankt dat je meedoet! Deze korte en interactieve enquête bestaat uit 12 vragen. Bij elke vraag zie je 5 mascottes. Sleep ze in de volgorde die voor jou het meest logisch voelt — van 1 (meest passend) tot 5 (minst passend). Niet te lang over nadenken: vertrouw op je eerste indruk!',
+    captchaPrompt: 'Verifieer dat je een mens bent',
     privacyTitle: 'Privacy Verklaring',
     privacyIntro:
       'Door deel te nemen aan deze enquête ga je akkoord met het volgende:',
@@ -74,6 +75,7 @@ export const translations = {
     title: 'Mascot Survey',
     welcome:
       "👋 Welcome and thank you for participating! This short interactive survey consists of 12 questions. For each question, you'll see 5 mascots. Drag them in the order that feels most logical to you — from 1 (most suitable) to 5 (least suitable). Don't think too long: trust your first impression!",
+    captchaPrompt: "Please verify that you're human",
     privacyTitle: 'Privacy Statement',
     privacyIntro:
       'By participating in this survey, you agree to the following:',


### PR DESCRIPTION
## Summary
- support localized captcha prompt via new translation strings
- pass translation object to `CaptchaVerification`
- use new strings inside `CaptchaVerification`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684740c89c9c8324b40e28c10c8c7d40