### PR TITLE
Fix README wording for submission check env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Copy `.env.example` to `.env` and provide values for the variables listed below:
 
 - `VITE_SHEET_DB_API` – URL of the SheetDB API endpoint used to store survey results.
 - `VITE_RECAPTCHA_SITE_KEY` – Google reCAPTCHA site key used to verify submissions.
-- `VITE_DISABLE_SUBMISSION_CHECK` – Set to `false` when you want to enable the one‑time submission check that prevents multiple answers from the same browser.
+- `VITE_DISABLE_SUBMISSION_CHECK` – Defaults to `false` to enforce one-time submission; set to `true` to disable this check.
 - `VITE_DISABLE_CAPTCHA` – Set to `true` to disable the CAPTCHA locally.
 
 Environment variables are read when the server starts. After changing a variable, restart the dev server or rebuild the project for the new values to take effect.


### PR DESCRIPTION
## Summary
- clarify the description of `VITE_DISABLE_SUBMISSION_CHECK` in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684742ca16f48324a847c6bf9e4f98fa