### PR TITLE
Fix standard lint errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ import {
 } from '@dnd-kit/core'
 import {
   SortableContext,
-  verticalListSortingStrategy,
   rectSortingStrategy
 } from '@dnd-kit/sortable'
 import { QUESTIONS } from './data/questions'
@@ -17,6 +16,7 @@ import CaptchaVerification from './components/CaptchaVerification'
 import EnvironmentCheck from './components/EnvironmentCheck'
 import { hasUserSubmitted, markAsSubmitted } from './utils/submissionTracker'
 import { translations } from './data/translations'
+import { getItem, setItem } from './utils/storage'
 
 const validateForm = (form) => {
   const errors = {}
@@ -63,7 +63,6 @@ export const validateMascotRankings = (answers, questions) => {
 }
 
 export default function App () {
-  const [isMobile, setIsMobile] = React.useState(window.innerWidth <= 639)
   const [isVerified, setIsVerified] = React.useState(false)
   const [hasSubmitted, setHasSubmitted] = useState(false)
   const [privacyConsent, setPrivacyConsent] = useState(false)
@@ -72,12 +71,12 @@ export default function App () {
   const [order, setOrder] = useState([])
   const [form, setForm] = useState({ age: '', gender: '', education: '' })
   const [submitted, setSubmitted] = useState(false)
-  const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'nl')
+  const [lang, setLang] = useState(() => getItem('lang') || 'nl')
   const [formErrors, setFormErrors] = useState({})
 
   // Update localStorage when language changes
   React.useEffect(() => {
-    localStorage.setItem('lang', lang)
+    setItem('lang', lang)
   }, [lang])
 
   const t = translations[lang]
@@ -128,7 +127,7 @@ export default function App () {
       if (step + 1 < QUESTIONS.length) {
         const nextQ = QUESTIONS[step + 1]
         nextQ.options.forEach(file => {
-          const img = new Image()
+          const img = new window.Image()
           img.src = `mascots/${nextQ.id}/${file}`
         })
       }
@@ -185,7 +184,7 @@ export default function App () {
 
       // Validate mascot rankings
       if (!validateMascotRankings(answers, QUESTIONS)) {
-        alert('Zorg ervoor dat alle mascottes zijn gerangschikt voordat je de enquête verstuurt.')
+        window.alert('Zorg ervoor dat alle mascottes zijn gerangschikt voordat je de enquête verstuurt.')
         return
       }
 
@@ -231,7 +230,7 @@ export default function App () {
       setSubmitted(true)
     } catch (error) {
       console.error('Submission error:', error)
-      alert('Er is een fout opgetreden bij het versturen van de gegevens. Probeer het opnieuw.')
+      window.alert('Er is een fout opgetreden bij het versturen van de gegevens. Probeer het opnieuw.')
     }
   }
 

--- a/src/__tests__/languagePersistence.test.jsx
+++ b/src/__tests__/languagePersistence.test.jsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from '../App.jsx'
+
+// Ensure a clean DOM for each test
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('language preference persistence', () => {
+  it('saves selected language to localStorage', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(<App />)
+    })
+
+    // Default should be nl
+    expect(window.localStorage.getItem('lang')).toBe('nl')
+
+    const englishBtn = container.querySelector('img[alt="English"]').closest('button')
+    act(() => {
+      englishBtn.dispatchEvent(new window.MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(window.localStorage.getItem('lang')).toBe('en')
+    root.unmount()
+  })
+})

--- a/src/components/CaptchaVerification.jsx
+++ b/src/components/CaptchaVerification.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import ReCAPTCHA from 'react-google-recaptcha'
 
 const CaptchaVerification = ({ onVerify }) => {

--- a/src/components/SortableMascot.jsx
+++ b/src/components/SortableMascot.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { LABEL_MAP } from '../data/questions'
+import { getItem } from '../utils/storage'
 
 export default function SortableMascot ({ id, src, rank }) {
   const {
@@ -20,7 +21,7 @@ export default function SortableMascot ({ id, src, rank }) {
   }
 
   const type = id.split('-')[1].replace('.png', '')
-  const lang = localStorage.getItem('lang') || 'nl'
+  const lang = getItem('lang') || 'nl'
   const label = LABEL_MAP[lang]?.[type] ?? 'Mascotte'
   const [fallback, setFallback] = useState(false)
 

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,4 @@
+export const getItem = (key) => window.localStorage.getItem(key)
+export const setItem = (key, value) => window.localStorage.setItem(key, value)
+export const getJSON = (key) => JSON.parse(getItem(key) || '{}')
+export const setJSON = (key, value) => setItem(key, JSON.stringify(value))

--- a/src/utils/submissionTracker.js
+++ b/src/utils/submissionTracker.js
@@ -1,4 +1,5 @@
 import FingerprintJS from '@fingerprintjs/fingerprintjs'
+import { getJSON, setJSON } from './storage'
 
 let fpPromise = null
 
@@ -19,17 +20,17 @@ export const hasUserSubmitted = async () => {
     return false
   }
   const fingerprint = await getFingerprint()
-  const submissions = JSON.parse(localStorage.getItem('surveySubmissions') || '{}')
+  const submissions = getJSON('surveySubmissions')
   return !!submissions[fingerprint]
 }
 
 // Mark survey as submitted
 export const markAsSubmitted = async () => {
   const fingerprint = await getFingerprint()
-  const submissions = JSON.parse(localStorage.getItem('surveySubmissions') || '{}')
+  const submissions = getJSON('surveySubmissions')
   submissions[fingerprint] = {
     timestamp: new Date().toISOString(),
     userAgent: navigator.userAgent
   }
-  localStorage.setItem('surveySubmissions', JSON.stringify(submissions))
+  setJSON('surveySubmissions', submissions)
 }


### PR DESCRIPTION
## Summary
- cleanup imports in `App.jsx`
- remove unused state
- persist language using `window.localStorage`
- use `window.Image` and `window.alert` globals
- fix captcha component import
- access `localStorage` via `window` in utils and components
- centralize localStorage access in utils
- add test for language persistence

## Testing
- `npx --yes standard`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68473cfb47308324bbe86cdcad5f0b85